### PR TITLE
chore(deploy): update fly.io configuration and environment

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -28,4 +28,4 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_CHAT }}

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,0 +1,18 @@
+# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+
+name: Fly Deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    concurrency: deploy-group    # optional: ensure only one action runs at a time
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+ARG GO_VERSION=1
+FROM golang:${GO_VERSION}-bookworm as builder
+
+WORKDIR /usr/src/app
+
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+
+RUN go build -v -o /usr/local/bin/app ./cmd/api
+
+FROM debian:bookworm
+
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates
+
+COPY --from=builder /usr/local/bin/app /usr/local/bin/app
+
+CMD ["/usr/local/bin/app"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,17 +1,18 @@
-# fly.toml app configuration file generated for short-spot on 2024-10-18T07:25:47-03:00
+# fly.toml app configuration file generated for chat-solitary-butterfly-9161 on 2025-03-12T01:18:39-03:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = 'chat'
+app = 'chat-solitary-butterfly-9161'
 primary_region = 'gig'
 
 [build]
   [build.args]
-    GO_VERSION = '1.23'
+    GO_VERSION = '1.24.1'
 
 [env]
-  BASE_URL="https://short-spot.fly.dev/"
+  BASE_URL = 'https://chat-vit0rrs-projects.vercel.app/'
+  PORT = '8080'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
- Update app name to chat-solitary-butterfly-9161
- Upgrade Go version to 1.24.1
- Update BASE_URL to point to Vercel deployment
- Add explicit PORT environment variable
- Update FLY_API_TOKEN secret reference to FLY_API_TOKEN_CHAT