### PR TITLE
feat(api): centralize backend URL configuration

### DIFF
--- a/config/api.go
+++ b/config/api.go
@@ -8,7 +8,6 @@ type API struct {
 	Mongo Mongo `hcl:"mongo,block"`
 	Redis Redis `hcl:"redis,block"`
 	BaseURL BaseURL `hcl:"base_url,block"`
-	BackendURL BackendURL `hcl:"backend_url,block"`
 }
 
 type Mongo struct {
@@ -37,9 +36,6 @@ func GetDefaltAPIConfig(cfg Config) API {
 		},
 		BaseURL: BaseURL{
 			Url: os.Getenv("BASE_URL"),
-		},
-		BackendURL: BackendURL{
-			Url: os.Getenv("BACKEND_URL"),
 		},
 	}
 }

--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,6 @@ primary_region = 'gig'
 
 [env]
   BASE_URL = 'https://chat-vit0rrs-projects.vercel.app/'
-  BACKEND_URL = 'https://chat-solitary-butterfly-9161.fly.dev/'
   PORT = '8080'
 
 [http_service]

--- a/front/app/login/page.tsx
+++ b/front/app/login/page.tsx
@@ -17,9 +17,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import axios from "axios";
 import Link from "next/link";
 
-const API_URL =
-  process.env.NEXT_PUBLIC_API_URL ||
-  "https://chat-solitary-butterfly-9161.fly.dev/api/v1";
+const API_URL = process.env.BACKEND_ROOT_URL;
 
 export default function LoginPage() {
   const [email, setEmail] = useState("");
@@ -36,7 +34,7 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const response = await axios.post(`${API_URL}/auth/login`, {
+      const response = await axios.post(`${API_URL}/api/v1/auth/login`, {
         email,
         password,
       });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://chat-solitary-butterfly-9161.fly.dev/api/v1';
+const API_URL = process.env.BACKEND_ROOT_URL;
 
 export type RegisterRequest = {
     email: string;
@@ -20,17 +20,17 @@ export type AuthResponse = {
 }
 
 export const register = async (data: RegisterRequest): Promise<AuthResponse> => {
-    const response = await axios.post(`${API_URL}/auth/register`, data);
+    const response = await axios.post(`${API_URL}/api/v1/auth/register`, data);
     return response.data;
 };
 
 export const login = async (data: LoginRequest): Promise<AuthResponse> => {
-    const response = await axios.post(`${API_URL}/auth/login`, data);
+    const response = await axios.post(`${API_URL}/api/v1/auth/login`, data);
     return response.data;
 };
 
 export const deleteUser = async (userId: string, token: string): Promise<void> => {
-    await axios.delete(`${API_URL}/auth/user`, {
+    await axios.delete(`${API_URL}/api/v1/auth/user`, {
         data: { user_id: userId },
         headers: {
             Authorization: `Bearer ${token}`,

--- a/front/lib/rooms.ts
+++ b/front/lib/rooms.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://chat-solitary-butterfly-9161.fly.dev/api/v1';
+const API_URL = process.env.BACKEND_ROOT_URL;
 
 export type Room = {
     room_id: string;
@@ -33,7 +33,7 @@ export type Message = {
 }
 
 export const getRooms = async (token: string): Promise<Room[]> => {
-    const response = await axios.get<RoomsList>(`${API_URL}/rooms`, {
+    const response = await axios.get<RoomsList>(`${API_URL}/api/v1/rooms`, {
         headers: {
             Authorization: `Bearer ${token}`,
         },
@@ -59,7 +59,7 @@ export const registerUserInRoom = async (
 
     try {
         const response = await axios.post<RoomDetails>(
-            `${API_URL}/rooms/${id}/register-user`,
+            `${API_URL}/api/v1/rooms/${id}/register-user`,
             {
                 user_id: users[0].id,
                 nickname: users[0].nickname,
@@ -96,7 +96,7 @@ type RoomDetails = {
 };
 
 export const getRoom = async (roomId: string, token: string): Promise<Room> => {
-    const response = await axios.get(`${API_URL}/rooms/${roomId}`, {
+    const response = await axios.get(`${API_URL}/api/v1/rooms/${roomId}`, {
         headers: {
             Authorization: `Bearer ${token}`,
         },
@@ -116,7 +116,7 @@ export const getMessages = async (
 
     try {
         const response = await axios.get<Message[]>(
-            `${API_URL}/rooms/${roomId}/messages`,
+            `${API_URL}/api/v1/rooms/${roomId}/messages`,
             {
                 params: {
                     page,
@@ -140,7 +140,7 @@ export async function joinRoom(roomId: string, userId: string, nickname: string,
         throw new Error('Authentication required');
     }
 
-    const response = await fetch(`${API_URL}/rooms/${roomId}/register-user`, {
+    const response = await fetch(`${API_URL}/api/v1/rooms/${roomId}/register-user`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',

--- a/front/lib/useRoomWebSocket.ts
+++ b/front/lib/useRoomWebSocket.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { Room } from './rooms';
 
+const WS_URL = process.env.BACKEND_WS_ROOT_URL;
+
 export function useRoomWebSocket(roomId: string, userId: string, token: string) {
     const [room, setRoom] = useState<Room | null>(null);
     const [isConnected, setIsConnected] = useState(false);
@@ -12,7 +14,7 @@ export function useRoomWebSocket(roomId: string, userId: string, token: string) 
             return;
         }
 
-        const wsUrl = `wss://chat-solitary-butterfly-9161.fly.dev/api/v1/rooms/${roomId}/watch?user_id=${userId}`;
+        const wsUrl = `wss://${WS_URL}/api/v1/rooms/${roomId}/watch?user_id=${userId}`;
         console.log('Connecting to Room WebSocket:', wsUrl);
 
         const ws = new WebSocket(wsUrl);

--- a/front/lib/useWebSocket.ts
+++ b/front/lib/useWebSocket.ts
@@ -2,6 +2,8 @@ import { AxiosError } from 'axios';
 import { useEffect, useRef, useState } from 'react';
 import { Message, getMessages } from './rooms';
 
+const WS_URL = process.env.BACKEND_WS_ROOT_URL;
+
 export function useWebSocket(roomId: string, userId: string, nickname: string, token: string) {
     const [messages, setMessages] = useState<Message[]>([]);
     const [isConnected, setIsConnected] = useState(false);
@@ -73,7 +75,7 @@ export function useWebSocket(roomId: string, userId: string, nickname: string, t
             return;
         }
 
-        const wsUrl = `wss://chat-solitary-butterfly-9161.fly.dev/api/v1/ws?room_id=${roomId}&user_id=${userId}&nickname=${encodeURIComponent(nickname)}`;
+        const wsUrl = `wss://${WS_URL}/api/v1/ws?room_id=${roomId}&user_id=${userId}&nickname=${encodeURIComponent(nickname)}`;
         console.log('Connecting to WebSocket:', wsUrl);
 
         const ws = new WebSocket(wsUrl);

--- a/front/next.config.ts
+++ b/front/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    BACKEND_ROOT_URL: process.env.BACKEND_ROOT_URL,
+    BACKEND_WS_ROOT_URL: process.env.BACKEND_WS_ROOT_URL,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
This commit centralizes the backend API URL configuration by:
- Removing hardcoded backend URLs throughout the codebase
- Adding environment variables BACKEND_ROOT_URL and BACKEND_WS_ROOT_URL
- Updating all API endpoint paths to include /api/v1 prefix
- Removing redundant BACKEND_URL configuration from server config
- Exposing environment variables through Next.js config