### PR TITLE
refactor(auth): migrate register functionality to Next.js API route

### DIFF
--- a/front/app/api/auth/register/route.ts
+++ b/front/app/api/auth/register/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+    const { email, password, nickname } = await req.json();
+
+    const response = await fetch(`${process.env.BACKEND_ROOT_URL}/api/v1/auth/register`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password, nickname }),
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data);
+} 

--- a/front/app/register/page.tsx
+++ b/front/app/register/page.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { register, RegisterRequest } from "@/lib/auth";
 import { useAuth } from "@/lib/auth-context";
 import {
   Card,
@@ -18,6 +17,12 @@ import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Label } from "@/components/ui/label";
 import { Loader2 } from "lucide-react";
+
+type RegisterRequest = {
+  email: string;
+  password: string;
+  nickname: string;
+};
 
 export default function RegisterPage() {
   const [formData, setFormData] = useState<RegisterRequest>({
@@ -43,8 +48,11 @@ export default function RegisterPage() {
     setLoading(true);
 
     try {
-      const response = await register(formData);
-      const { token, user_id, nickname } = response;
+      const response = await fetch(`/api/auth/register`, {
+        method: "POST",
+        body: JSON.stringify(formData),
+      });
+      const { token, user_id, nickname } = await response.json();
       authLogin(token, user_id, nickname);
       router.push("/rooms");
     } catch (err: unknown) {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -2,33 +2,6 @@ import axios from 'axios';
 
 const API_URL = process.env.BACKEND_ROOT_URL;
 
-export type RegisterRequest = {
-    email: string;
-    password: string;
-    nickname: string;
-}
-
-export type LoginRequest = {
-    email: string;
-    password: string;
-}
-
-export type AuthResponse = {
-    token: string;
-    user_id: string;
-    nickname: string;
-}
-
-export const register = async (data: RegisterRequest): Promise<AuthResponse> => {
-    const response = await axios.post(`${API_URL}/api/v1/auth/register`, data);
-    return response.data;
-};
-
-export const login = async (data: LoginRequest): Promise<AuthResponse> => {
-    const response = await axios.post(`${API_URL}/api/v1/auth/login`, data);
-    return response.data;
-};
-
 export const deleteUser = async (userId: string, token: string): Promise<void> => {
     await axios.delete(`${API_URL}/api/v1/auth/user`, {
         data: { user_id: userId },


### PR DESCRIPTION
- Remove direct API calls from client-side auth library
- Move RegisterRequest type definition to register page component
- Replace axios API calls with fetch to local API route
- Improve security by removing exposed API_URL from client-side code