### PR TITLE
refactor: replace direct API calls with Next.js API routes

### DIFF
--- a/front/app/api/room/route.ts
+++ b/front/app/api/room/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+    const roomId = req.nextUrl.searchParams.get('roomId');
+    const token = req.headers.get('Authorization')?.split(' ')[1];
+
+    const response = await fetch(`${process.env.BACKEND_ROOT_URL}/api/v1/rooms/${roomId}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+        },
+    });
+
+    const data = await response.json();
+
+    return NextResponse.json(data);
+} 

--- a/front/app/rooms/[roomId]/page.tsx
+++ b/front/app/rooms/[roomId]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState, use } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
-import { getRoom, Room, joinRoom } from "@/lib/rooms";
+import { Room, joinRoom } from "@/lib/rooms";
 import Link from "next/link";
 import Header from "@/components/Header";
 import Chat from "@/components/Chat";
@@ -42,7 +42,13 @@ export default function RoomDetailPage({
       try {
         setLoading(true);
         setError("");
-        const roomData = await getRoom(roomId, token);
+        const response = await fetch(`/api/room?roomId=${roomId}`, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        const roomData = await response.json();
         setRoom(roomData);
       } catch (err: unknown) {
         console.error("Error fetching room:", err);
@@ -77,7 +83,13 @@ export default function RoomDetailPage({
       setError("");
       await joinRoom(roomId, user.id, user.nickname, token);
       // Fetch the updated room data
-      const updatedRoom = await getRoom(roomId, token);
+      const response = await fetch(`/api/room?roomId=${roomId}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const updatedRoom = await response.json();
       setRoom(updatedRoom);
     } catch (err) {
       console.error("Error joining room:", err);

--- a/front/lib/rooms.ts
+++ b/front/lib/rooms.ts
@@ -32,15 +32,6 @@ export type Message = {
     timestamp: string;
 }
 
-export const getRoom = async (roomId: string, token: string): Promise<Room> => {
-    const response = await axios.get(`${API_URL}/api/v1/rooms/${roomId}`, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-        },
-    });
-    return response.data;
-};
-
 export const getMessages = async (
     roomId: string,
     token: string,


### PR DESCRIPTION
- Remove getRoom function from rooms.ts utility
- Replace direct backend API calls with fetch requests to local Next.js API routes
- Update room fetching logic in room detail page to use the new API route
- Maintain same authentication flow with token passing