### PR TITLE
feat(auth): improve WebSocket authentication error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ DATABASE_URL=mongodb://docker:docker@localhost:27017/
 REDIS_URL=redis://localhost:6379
 
 ALLOWED_ORIGINS=http://localhost:3000,...
+JWT_SECRET=your-secret-key

--- a/api/internal/chat-service/http.go
+++ b/api/internal/chat-service/http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/redis/go-redis/v9"
 	"github.com/vit0rr/chat/pkg/deps"
+	"github.com/vit0rr/chat/pkg/log"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -31,7 +32,18 @@ func NewHTTP(deps *deps.Deps, db *mongo.Database, redisClient *redis.Client) *HT
 }
 
 func (h *HTTP) WebSocket(w http.ResponseWriter, r *http.Request) (interface{}, error) {
-	return h.service.WebSocket(w, r)
+	result, err := h.service.WebSocket(w, r)
+	if err != nil {
+		log.Error(r.Context(), "WebSocket error", log.ErrAttr(err))
+		w.WriteHeader(http.StatusUnauthorized)
+		return ErrorResponse{
+			Error:   err.Error(),
+			Code:    http.StatusUnauthorized,
+			ErrorID: "websocket_error",
+		}, nil
+	}
+
+	return result, nil
 }
 
 func (h *HTTP) RegisterUser(w http.ResponseWriter, r *http.Request) (interface{}, error) {

--- a/front/lib/useWebSocket.ts
+++ b/front/lib/useWebSocket.ts
@@ -115,8 +115,13 @@ export function useWebSocket(roomId: string, userId: string, nickname: string, t
             setIsConnected(false);
         };
 
-        ws.onclose = () => {
-            console.log('WebSocket disconnected');
+        ws.onclose = (event) => {
+            if (event.reason === 'Invalid authentication token') {
+                setError('Unable to connect. Looks like we changed our signature. Please logout and login again to fix it.');
+            } else {
+                setError('Disconnected from chat');
+            }
+
             setIsConnected(false);
         };
 


### PR DESCRIPTION
- Add proper error handling for WebSocket authentication failures
- Display user-friendly message when token is invalid or expired
- Prompt users to log out and log in again to refresh their session
- Close WebSocket connection with appropriate status code on auth failure
- Add JWT_SECRET to environment variables example
- Remove debug console logs from token validation