### PR TITLE
feat(auth): implement JWT token rotation mechanism

### DIFF
--- a/api/internal/chat-service/service.go
+++ b/api/internal/chat-service/service.go
@@ -226,21 +226,9 @@ func (s *Service) WebSocket(w http.ResponseWriter, r *http.Request) (interface{}
 		return nil, fmt.Errorf("websocket accept error: %v", err)
 	}
 
-		// Validate the token (you'll need to implement this function)
-		// claims, err := validateToken(ctx, token)
-		// if err != nil {
-		// 	log.Error(ctx, "Invalid authentication token", log.ErrAttr(err))
-		// 	conn.Close(websocket.StatusPolicyViolation, "Invalid authentication token")
-			
-		// 	return nil, nil
-		// }
-		// tokenUserID := claims.Sub // Extract from your JWT claims
-		requestedUserID := r.URL.Query().Get("user_id")
+	requestedUserID := r.URL.Query().Get("user_id")
 	
-		// if tokenUserID != requestedUserID {
-		// 	log.Error(ctx, "User ID mismatch", log.AnyAttr("token_user_id", tokenUserID), log.AnyAttr("requested_user_id", requestedUserID))
-		// 	return nil, fmt.Errorf("user ID in token does not match requested user ID")
-		// }
+
 
 	roomID := r.URL.Query().Get("room_id")
 	nickname := r.URL.Query().Get("nickname")
@@ -1273,33 +1261,3 @@ func newError(errKey string) Error {
 		ErrorCode:    &errMsg.Code,
 	}
 }
-
-// func validateToken(ctx context.Context, tokenString string) (*Claims, error) {
-// 	// Parse the token
-// 	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
-// 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-// 			log.Error(ctx, "Unexpected signing method", log.ErrAttr(fmt.Errorf("unexpected signing method: %v", token.Header["alg"])))
-// 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-// 		}
-
-// 		log.Info(ctx, "Token secret", log.AnyAttr("secret", os.Getenv("JWT_SECRET")))
-// 		return []byte(os.Getenv("JWT_SECRET")), nil
-// 	})
-
-
-// 	if err != nil {
-// 		log.Error(ctx, "Failed to parse token", log.ErrAttr(err))
-// 		return nil, err
-// 	}
-
-// 	log.Info(ctx, "Token parsed", log.AnyAttr("token", token))
-
-// 	// Extract and return claims
-// 	if claims, ok := token.Claims.(*Claims); ok && token.Valid {
-// 		return claims, nil
-// 	}
-
-
-// 	log.Error(ctx, "Invalid token", log.ErrAttr(fmt.Errorf("invalid token")))
-// 	return nil, fmt.Errorf("invalid token")
-// }

--- a/config/config.go
+++ b/config/config.go
@@ -14,11 +14,11 @@ type Config struct {
 	Env    Env    `hcl:"env,block"`
 	JWT    JWT    `hcl:"jwt,block"`
 	APIKey string `hcl:"api_key,attr"`
-	OldJWT OldJWT `hcl:"old_jwt,block"`
 }
 
 type JWT struct {
 	Secret string `hcl:"secret,attr"`
+	OldSecret string `hcl:"old_secret,attr"`
 }
 
 type OldJWT struct {
@@ -59,6 +59,7 @@ func DefaultConfig(cfg Config) Config {
 		API: GetDefaltAPIConfig(cfg),
 		JWT: JWT{
 			Secret: os.Getenv("JWT_SECRET"),
+			OldSecret: os.Getenv("OLD_JWT_SECRET"),
 		},
 		Env: Env{
 			Port: os.Getenv("PORT"),
@@ -67,8 +68,5 @@ func DefaultConfig(cfg Config) Config {
 			AllowedOrigins: os.Getenv("ALLOWED_ORIGINS"),
 		},
 		APIKey: os.Getenv("API_KEY"),
-		OldJWT: OldJWT{
-			Secret: os.Getenv("OLD_JWT_SECRET"),
-		},
 	}
 }

--- a/front/app/api/rooms/route.ts
+++ b/front/app/api/rooms/route.ts
@@ -13,7 +13,11 @@ export async function GET(req: NextRequest) {
 
     const data = await response.json();
 
-    return NextResponse.json(data.rooms);
+    return NextResponse.json(data.rooms, {
+        headers: {
+            'X-New-Token': response.headers.get('X-New-Token') || ''
+        }
+    });
 }
 
 export async function POST(req: NextRequest) {

--- a/front/app/rooms/page.tsx
+++ b/front/app/rooms/page.tsx
@@ -36,6 +36,10 @@ export default function RoomsPage() {
           },
         });
         const roomsData = await roomsResponse.json();
+        const newToken = roomsResponse.headers.get("X-New-Token");
+        if (newToken) {
+          localStorage.setItem("token", newToken);
+        }
         setRooms(roomsData);
       } catch (error) {
         console.error("Error fetching rooms:", error);

--- a/pkg/middleware/jwt.go
+++ b/pkg/middleware/jwt.go
@@ -27,11 +27,17 @@ func JWTAuth(deps *deps.Deps) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Get token from Authorization header
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
-				http.Error(w, "Authorization header required", http.StatusUnauthorized)
-				return
+				// As I know, it's not possible to pass a header to a websocket, 
+				// so I'm checking if the token is in the query params too
+				tokenString := r.URL.Query().Get("token")
+				if tokenString == "" {
+					http.Error(w, "Authorization header required", http.StatusUnauthorized)
+					return
+				}
+
+				authHeader = "Bearer " + tokenString
 			}
 
 			// Extract the token
@@ -41,13 +47,52 @@ func JWTAuth(deps *deps.Deps) func(http.Handler) http.Handler {
 				return
 			}
 
-			// Parse and validate the token
+			// Parse and validate the token with current secret
 			token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 				return []byte(deps.Config.JWT.Secret), nil
 			})
 
+			// If token is invalid with current secret, try with old secret
 			if err != nil || !token.Valid {
-				http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
+				oldToken, oldErr := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+					return []byte(deps.Config.JWT.OldSecret), nil
+				})
+
+				if oldErr != nil || !oldToken.Valid {
+					http.Error(w, "Invalid or expired token", http.StatusUnauthorized)
+					return
+				}
+
+				// token is valid with old secret, issue a new token
+				claims, ok := oldToken.Claims.(jwt.MapClaims)
+				if !ok {
+					http.Error(w, "Invalid token claims", http.StatusUnauthorized)
+					return
+				}
+
+				userClaims := UserClaims{
+					UserID:   claims["sub"].(string),
+					Email:    claims["email"].(string),
+					Nickname: claims["nickname"].(string),
+				}
+
+				newToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+					"sub":      userClaims.UserID,
+					"email":    userClaims.Email,
+					"nickname": userClaims.Nickname,
+					"exp":      claims["exp"], // Preserve original expiration
+				})
+
+				newTokenString, signErr := newToken.SignedString([]byte(deps.Config.JWT.Secret))
+				if signErr != nil {
+					http.Error(w, "Error creating new token", http.StatusInternalServerError)
+					return
+				}
+
+				w.Header().Set("X-New-Token", newTokenString)
+
+				ctx := context.WithValue(r.Context(), UserContextKey, userClaims)
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 
@@ -80,8 +125,17 @@ func isPublicPath(path string) bool {
 		"/",
 	}
 
+	if path == "/" {
+		return true
+	}
+	
+
+	if strings.HasPrefix(path, "/swagger") {
+		return true
+	}
+
 	for _, pp := range publicPaths {
-		if strings.HasPrefix(path, pp) {
+		if path == pp {
 			return true
 		}
 	}


### PR DESCRIPTION
- Add token rotation between old and new JWT secrets
- Modify JWT middleware to check token validity with both current and old secrets
- Implement client-side handling of new tokens returned via X-New-Token header
- Support token authentication for WebSocket connections via query parameter
- Refactor JWT configuration to include OldSecret field
- Fix path matching logic in isPublicPath function

BREAKING CHANGE: The OldJWT config block has been removed in favor of adding an OldSecret field to the JWT block. Environment variables remain the same.