### PR TITLE
feat: implement token validation with automatic user logout

### DIFF
--- a/front/app/api/rooms/route.ts
+++ b/front/app/api/rooms/route.ts
@@ -11,13 +11,13 @@ export async function GET(req: NextRequest) {
         },
     });
 
+    if (response.status === 401) {
+        return NextResponse.json({ error: "Unauthorized", shouldSignOut: true }, { status: 401 });
+    }
+
     const data = await response.json();
 
-    return NextResponse.json(data.rooms, {
-        headers: {
-            'X-New-Token': response.headers.get('X-New-Token') || ''
-        }
-    });
+    return NextResponse.json(data.rooms);
 }
 
 export async function POST(req: NextRequest) {
@@ -35,6 +35,10 @@ export async function POST(req: NextRequest) {
             nickname: nickname,
         }),
     });
+
+    if (response.status === 401) {
+        return NextResponse.json({ error: "Unauthorized", shouldSignOut: true }, { status: 401 });
+    }
 
     const data = await response.json();
 

--- a/front/app/rooms/page.tsx
+++ b/front/app/rooms/page.tsx
@@ -19,14 +19,15 @@ import { Badge } from "@/components/ui/badge";
 import { Loader2 } from "lucide-react";
 
 export default function RoomsPage() {
-  const { token } = useAuth();
+  const { token, logout } = useAuth();
   const [rooms, setRooms] = useState<Room[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
-
   useEffect(() => {
     const fetchRooms = async () => {
-      if (!token) return;
+      if (!token) {
+        return;
+      }
 
       try {
         setLoading(true);
@@ -35,6 +36,12 @@ export default function RoomsPage() {
             Authorization: `Bearer ${token}`,
           },
         });
+
+        if (roomsResponse.status === 401) {
+          logout();
+          return;
+        }
+
         const roomsData = await roomsResponse.json();
         const newToken = roomsResponse.headers.get("X-New-Token");
         if (newToken) {
@@ -49,7 +56,7 @@ export default function RoomsPage() {
     };
 
     fetchRooms();
-  }, [token]);
+  }, [token, logout]);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">

--- a/front/lib/auth-context.tsx
+++ b/front/lib/auth-context.tsx
@@ -90,7 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     ) {
       router.push("/rooms");
     }
-  }, [isAuthenticated, pathname, router, isLoading]);
+  }, [isAuthenticated, pathname, router, isLoading, token]);
 
   const login = (token: string, userId: string, nickname: string) => {
     const userData = {


### PR DESCRIPTION
This commit improves JWT authentication handling by:
- Removing token rotation logic with old secret in the JWT middleware
- Adding 401 status checks in API routes to detect invalid tokens
- Implementing immediate logout and redirect to login page when tokens are invalid
- Propagating authentication errors to the UI with helpful error messages

The changes ensure users are automatically logged out when their tokens become invalid, improving security and user experience by requiring re-authentication with valid credentials.