### PR TITLE
docs(api): add Swagger documentation to all API endpoints

### DIFF
--- a/api/internal/auth-service/service.go
+++ b/api/internal/auth-service/service.go
@@ -47,7 +47,16 @@ func NewService(deps *deps.Deps, db *mongo.Database) *Service {
 	}
 }
 
-// Register creates a new user account
+// @summary Register New User
+// @description Creates a new user account with email, password, and nickname
+// @tags auth
+// @router /api/v1/auth/register [post]
+// @param body body RegisterRequest true "User registration information"
+// @produce application/json
+// @success 201 {object} AuthResponse "User successfully registered with authentication token"
+// @failure 400 {object} error "Bad request - Missing required fields or invalid input"
+// @failure 409 {object} error "Conflict - User with this email already exists"
+// @failure 500 {object} error "Internal server error"
 func (s *Service) Register(ctx context.Context, b io.ReadCloser) (interface{}, error) {
 	var req RegisterRequest
 	err := json.NewDecoder(b).Decode(&req)
@@ -103,7 +112,16 @@ func (s *Service) Register(ctx context.Context, b io.ReadCloser) (interface{}, e
 	}, nil
 }
 
-// Login authenticates a user and returns a JWT token
+// @summary User Login
+// @description Authenticates a user with email and password, returning a JWT token
+// @tags auth
+// @router /api/v1/auth/login [post]
+// @param body body LoginRequest true "User login credentials"
+// @produce application/json
+// @success 200 {object} AuthResponse "User successfully authenticated with token"
+// @failure 400 {object} error "Bad request - Missing required fields"
+// @failure 401 {object} error "Unauthorized - Invalid email or password"
+// @failure 500 {object} error "Internal server error"
 func (s *Service) Login(ctx context.Context, b io.ReadCloser) (interface{}, error) {
 	var req LoginRequest
 	err := json.NewDecoder(b).Decode(&req)
@@ -151,7 +169,19 @@ func (s *Service) Login(ctx context.Context, b io.ReadCloser) (interface{}, erro
 	}, nil
 }
 
-// DeleteUser deletes a user account
+// @summary Delete User Account
+// @description Permanently removes a user account and all associated data
+// @tags auth
+// @router /api/v1/auth/user [delete]
+// @param body body DeleteUserRequest true "User ID to delete"
+// @produce application/json
+// @security JWT
+// @success 200 {object} map[string]string "User successfully deleted"
+// @failure 400 {object} error "Bad request - Missing user ID"
+// @failure 401 {object} error "Unauthorized - Missing or invalid authentication"
+// @failure 403 {object} error "Forbidden - Not authorized to delete this user"
+// @failure 404 {object} error "Not found - User doesn't exist"
+// @failure 500 {object} error "Internal server error"
 func (s *Service) DeleteUser(ctx context.Context, b io.ReadCloser) (interface{}, error) {
 	var req DeleteUserRequest
 	err := json.NewDecoder(b).Decode(&req)

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,8 +1,8 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Chat Service API",
-        "title": "Chat Service API",
+        "description": "Chat API",
+        "title": "Chat API",
         "termsOfService": "http://swagger.io/terms/",
         "contact": {
             "name": "API Support",
@@ -16,39 +16,161 @@
         "version": "1.0"
     },
     "paths": {
-        "/api/get-messages/": {
-            "get": {
-                "description": "Will return the messages of a room. It receives a room_id, page and limit by query params.",
-                "summary": "GetMessages",
+        "/api/v1/auth/login": {
+            "post": {
+                "description": "Authenticates a user with email and password, returning a JWT token",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "User Login",
+                "parameters": [
+                    {
+                        "description": "User login credentials",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/authservice.LoginRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Successfully processed chat",
+                        "description": "User successfully authenticated with token",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/chatservice.ChatMessage"
-                            }
+                            "$ref": "#/definitions/authservice.AuthResponse"
                         }
                     },
                     "400": {
-                        "description": "Invalid request body",
-                        "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
-                        }
+                        "description": "Bad request - Missing required fields",
+                        "schema": {}
+                    },
+                    "401": {
+                        "description": "Unauthorized - Invalid email or password",
+                        "schema": {}
                     },
                     "500": {
-                        "description": "Internal server error during processing",
-                        "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
-                        }
+                        "description": "Internal server error",
+                        "schema": {}
                     }
                 }
             }
         },
-        "/api/get-rooms/": {
+        "/api/v1/auth/register": {
+            "post": {
+                "description": "Creates a new user account with email, password, and nickname",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Register New User",
+                "parameters": [
+                    {
+                        "description": "User registration information",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/authservice.RegisterRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "User successfully registered with authentication token",
+                        "schema": {
+                            "$ref": "#/definitions/authservice.AuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request - Missing required fields or invalid input",
+                        "schema": {}
+                    },
+                    "409": {
+                        "description": "Conflict - User with this email already exists",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/user": {
+            "delete": {
+                "security": [
+                    {
+                        "JWT": []
+                    }
+                ],
+                "description": "Permanently removes a user account and all associated data",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Delete User Account",
+                "parameters": [
+                    {
+                        "description": "User ID to delete",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/authservice.DeleteUserRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User successfully deleted",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request - Missing user ID",
+                        "schema": {}
+                    },
+                    "401": {
+                        "description": "Unauthorized - Missing or invalid authentication",
+                        "schema": {}
+                    },
+                    "403": {
+                        "description": "Forbidden - Not authorized to delete this user",
+                        "schema": {}
+                    },
+                    "404": {
+                        "description": "Not found - User doesn't exist",
+                        "schema": {}
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {}
+                    }
+                }
+            }
+        },
+        "/api/v1/rooms": {
             "get": {
-                "description": "Returns a paginated list of all chat rooms",
-                "summary": "GetRooms",
+                "description": "Returns a paginated list of all available chat rooms with their users and status",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "List All Chat Rooms",
                 "parameters": [
                     {
                         "minimum": 1,
@@ -61,7 +183,7 @@
                         "maximum": 100,
                         "minimum": 1,
                         "type": "integer",
-                        "description": "Items per page (default: 10)",
+                        "description": "Items per page (default: 50)",
                         "name": "limit",
                         "in": "query"
                     }
@@ -70,7 +192,60 @@
                     "200": {
                         "description": "List of chat rooms retrieved successfully",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.RoomList"
+                            "$ref": "#/definitions/chatservice.RoomsList"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/rooms/{roomId}": {
+            "get": {
+                "description": "Returns detailed information about a specific chat room by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Get Room Details",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID (required)",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Room details retrieved successfully",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.RoomDetails"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
                         }
                     },
                     "404": {
@@ -80,7 +255,7 @@
                         }
                     },
                     "500": {
-                        "description": "Internal server error during processing",
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/chatservice.Error"
                         }
@@ -88,79 +263,270 @@
                 }
             }
         },
-        "/api/lock-room/": {
+        "/api/v1/rooms/{roomId}/lock": {
             "post": {
-                "description": "Will lock a room for the user. If the room is already locked by the user, it will unlock the room.",
-                "summary": "LockRoom",
+                "description": "Controls the lock status of a chat room. Locks room for exclusive use by a user or unlocks if already locked by same user.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rooms"
+                ],
+                "summary": "Lock or Unlock Room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID (required)",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User information for locking the room",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.LockRoomBody"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Successfully processed chat",
+                        "description": "Room lock status updated successfully",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "400": {
-                        "description": "Invalid request body",
+                        "description": "Bad request or missing required fields",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "403": {
+                        "description": "User not authorized to lock room",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal server error during processing",
+                        "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "$ref": "#/definitions/chatservice.Error"
                         }
                     }
                 }
             }
         },
-        "/api/register-user/": {
-            "post": {
-                "description": "Will register a user in a room. If the user is already registered, it will return the room without error.",
-                "summary": "RegisterUser",
-                "responses": {
-                    "200": {
-                        "description": "Successfully processed chat",
-                        "schema": {
-                            "$ref": "#/definitions/chatservice.RegisterUserResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request body",
-                        "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal server error during processing",
-                        "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/ws/": {
+        "/api/v1/rooms/{roomId}/messages": {
             "get": {
-                "description": "WebSocket",
-                "summary": "WebSocket",
+                "description": "Fetches paginated messages for a specific chat room",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "messages",
+                    "rooms"
+                ],
+                "summary": "Retrieve Room Messages",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID (required)",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Page number (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Items per page (default: 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Successfully processed chat",
+                        "description": "Messages retrieved successfully",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/chatservice.ChatMessage"
+                            }
                         }
                     },
                     "400": {
-                        "description": "Invalid request body",
+                        "description": "Bad request or missing room ID",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
                         }
                     },
                     "500": {
-                        "description": "Internal server error during processing",
+                        "description": "Internal server error",
                         "schema": {
-                            "$ref": "#/definitions/chatservice.Response"
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/rooms/{roomId}/register-user": {
+            "post": {
+                "description": "Adds a user to a chat room. Creates new user if needed. Returns existing room if user already registered.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "rooms",
+                    "users"
+                ],
+                "summary": "Register User to Room",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Room ID (required)",
+                        "name": "roomId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User information for registration",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.RegisterUserBody"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User successfully registered to room",
+                        "schema": {
+                            "$ref": "#/definitions/repositories.Room"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request or invalid input",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/ws": {
+            "get": {
+                "description": "Establishes a WebSocket connection for real-time messaging in a chat room",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "websocket",
+                    "rooms"
+                ],
+                "summary": "Real-time Chat WebSocket Connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Authentication token (required)",
+                        "name": "token",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User ID (required)",
+                        "name": "user_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Room ID (required)",
+                        "name": "room_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "User's display name (required)",
+                        "name": "nickname",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "101": {
+                        "description": "WebSocket connection successfully upgraded",
+                        "schema": {
+                            "$ref": "#/definitions/chatservice.ChatMessage"
+                        }
+                    },
+                    "400": {
+                        "description": "Missing required parameters or invalid request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized - Missing or invalid token",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - User not authorized to join room",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "404": {
+                        "description": "Room not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }
@@ -168,6 +534,53 @@
         }
     },
     "definitions": {
+        "authservice.AuthResponse": {
+            "type": "object",
+            "properties": {
+                "nickname": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "authservice.DeleteUserRequest": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "authservice.LoginRequest": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
+        "authservice.RegisterRequest": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                },
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
         "chatservice.ChatMessage": {
             "type": "object",
             "properties": {
@@ -215,6 +628,17 @@
                 }
             }
         },
+        "chatservice.LockRoomBody": {
+            "type": "object",
+            "properties": {
+                "room_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "chatservice.MessageType": {
             "type": "string",
             "enum": [
@@ -230,30 +654,13 @@
                 "SystemMessage"
             ]
         },
-        "chatservice.RegisterUserResponse": {
+        "chatservice.RegisterUserBody": {
             "type": "object",
             "properties": {
                 "nickname": {
                     "type": "string"
                 },
-                "room_id": {
-                    "type": "string"
-                },
                 "user_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "chatservice.Response": {
-            "type": "object",
-            "properties": {
-                "keys": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "message": {
                     "type": "string"
                 }
             }
@@ -276,26 +683,83 @@
                 "users": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/chatservice.RoomUser"
+                        "$ref": "#/definitions/repositories.UserRef"
                     }
                 }
             }
         },
-        "chatservice.RoomList": {
+        "chatservice.RoomListDetails": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "locked_by": {
+                    "type": "string"
+                },
+                "room_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/chatservice.RoomListUser"
+                    }
+                }
+            }
+        },
+        "chatservice.RoomListUser": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "nickname": {
+                    "type": "string"
+                }
+            }
+        },
+        "chatservice.RoomsList": {
             "type": "object",
             "properties": {
                 "rooms": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/chatservice.RoomDetails"
+                        "$ref": "#/definitions/chatservice.RoomListDetails"
                     }
                 }
             }
         },
-        "chatservice.RoomUser": {
+        "repositories.Room": {
             "type": "object",
             "properties": {
-                "external_id": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "lockedBy": {
+                    "type": "string"
+                },
+                "updatedAt": {
+                    "type": "string"
+                },
+                "users": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/repositories.UserRef"
+                    }
+                }
+            }
+        },
+        "repositories.UserRef": {
+            "type": "object",
+            "properties": {
+                "id": {
                     "type": "string"
                 },
                 "nickname": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,34 @@
 definitions:
+  authservice.AuthResponse:
+    properties:
+      nickname:
+        type: string
+      token:
+        type: string
+      user_id:
+        type: string
+    type: object
+  authservice.DeleteUserRequest:
+    properties:
+      user_id:
+        type: string
+    type: object
+  authservice.LoginRequest:
+    properties:
+      email:
+        type: string
+      password:
+        type: string
+    type: object
+  authservice.RegisterRequest:
+    properties:
+      email:
+        type: string
+      nickname:
+        type: string
+      password:
+        type: string
+    type: object
   chatservice.ChatMessage:
     properties:
       content:
@@ -30,6 +60,13 @@ definitions:
       error_message:
         type: string
     type: object
+  chatservice.LockRoomBody:
+    properties:
+      room_id:
+        type: string
+      user_id:
+        type: string
+    type: object
   chatservice.MessageType:
     enum:
     - text
@@ -41,22 +78,11 @@ definitions:
     x-enum-varnames:
     - TextMessage
     - SystemMessage
-  chatservice.RegisterUserResponse:
+  chatservice.RegisterUserBody:
     properties:
       nickname:
         type: string
-      room_id:
-        type: string
       user_id:
-        type: string
-    type: object
-  chatservice.Response:
-    properties:
-      keys:
-        items:
-          type: string
-        type: array
-      message:
         type: string
     type: object
   chatservice.RoomDetails:
@@ -71,19 +97,56 @@ definitions:
         type: string
       users:
         items:
-          $ref: '#/definitions/chatservice.RoomUser'
+          $ref: '#/definitions/repositories.UserRef'
         type: array
     type: object
-  chatservice.RoomList:
+  chatservice.RoomListDetails:
+    properties:
+      created_at:
+        type: string
+      locked_by:
+        type: string
+      room_id:
+        type: string
+      updated_at:
+        type: string
+      users:
+        items:
+          $ref: '#/definitions/chatservice.RoomListUser'
+        type: array
+    type: object
+  chatservice.RoomListUser:
+    properties:
+      id:
+        type: string
+      nickname:
+        type: string
+    type: object
+  chatservice.RoomsList:
     properties:
       rooms:
         items:
-          $ref: '#/definitions/chatservice.RoomDetails'
+          $ref: '#/definitions/chatservice.RoomListDetails'
         type: array
     type: object
-  chatservice.RoomUser:
+  repositories.Room:
     properties:
-      external_id:
+      createdAt:
+        type: string
+      id:
+        type: string
+      lockedBy:
+        type: string
+      updatedAt:
+        type: string
+      users:
+        items:
+          $ref: '#/definitions/repositories.UserRef'
+        type: array
+    type: object
+  repositories.UserRef:
+    properties:
+      id:
         type: string
       nickname:
         type: string
@@ -93,114 +156,362 @@ info:
     email: support@swagger.io
     name: API Support
     url: http://www.swagger.io/support
-  description: Chat Service API
+  description: Chat API
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: http://swagger.io/terms/
-  title: Chat Service API
+  title: Chat API
   version: "1.0"
 paths:
-  /api/get-messages/:
-    get:
-      description: Will return the messages of a room. It receives a room_id, page
-        and limit by query params.
+  /api/v1/auth/login:
+    post:
+      description: Authenticates a user with email and password, returning a JWT token
+      parameters:
+      - description: User login credentials
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/authservice.LoginRequest'
+      produces:
+      - application/json
       responses:
         "200":
-          description: Successfully processed chat
+          description: User successfully authenticated with token
           schema:
-            items:
-              $ref: '#/definitions/chatservice.ChatMessage'
-            type: array
+            $ref: '#/definitions/authservice.AuthResponse'
         "400":
-          description: Invalid request body
-          schema:
-            $ref: '#/definitions/chatservice.Response'
+          description: Bad request - Missing required fields
+          schema: {}
+        "401":
+          description: Unauthorized - Invalid email or password
+          schema: {}
         "500":
-          description: Internal server error during processing
+          description: Internal server error
+          schema: {}
+      summary: User Login
+      tags:
+      - auth
+  /api/v1/auth/register:
+    post:
+      description: Creates a new user account with email, password, and nickname
+      parameters:
+      - description: User registration information
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/authservice.RegisterRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: User successfully registered with authentication token
           schema:
-            $ref: '#/definitions/chatservice.Response'
-      summary: GetMessages
-  /api/get-rooms/:
+            $ref: '#/definitions/authservice.AuthResponse'
+        "400":
+          description: Bad request - Missing required fields or invalid input
+          schema: {}
+        "409":
+          description: Conflict - User with this email already exists
+          schema: {}
+        "500":
+          description: Internal server error
+          schema: {}
+      summary: Register New User
+      tags:
+      - auth
+  /api/v1/auth/user:
+    delete:
+      description: Permanently removes a user account and all associated data
+      parameters:
+      - description: User ID to delete
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/authservice.DeleteUserRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User successfully deleted
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad request - Missing user ID
+          schema: {}
+        "401":
+          description: Unauthorized - Missing or invalid authentication
+          schema: {}
+        "403":
+          description: Forbidden - Not authorized to delete this user
+          schema: {}
+        "404":
+          description: Not found - User doesn't exist
+          schema: {}
+        "500":
+          description: Internal server error
+          schema: {}
+      security:
+      - JWT: []
+      summary: Delete User Account
+      tags:
+      - auth
+  /api/v1/rooms:
     get:
-      description: Returns a paginated list of all chat rooms
+      description: Returns a paginated list of all available chat rooms with their
+        users and status
       parameters:
       - description: 'Page number (default: 1)'
         in: query
         minimum: 1
         name: page
         type: integer
-      - description: 'Items per page (default: 10)'
+      - description: 'Items per page (default: 50)'
         in: query
         maximum: 100
         minimum: 1
         name: limit
         type: integer
+      produces:
+      - application/json
       responses:
         "200":
           description: List of chat rooms retrieved successfully
           schema:
-            $ref: '#/definitions/chatservice.RoomList'
+            $ref: '#/definitions/chatservice.RoomsList'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+      summary: List All Chat Rooms
+      tags:
+      - rooms
+  /api/v1/rooms/{roomId}:
+    get:
+      description: Returns detailed information about a specific chat room by ID
+      parameters:
+      - description: Room ID (required)
+        in: path
+        name: roomId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Room details retrieved successfully
+          schema:
+            $ref: '#/definitions/chatservice.RoomDetails'
+        "400":
+          description: Bad request
+          schema:
+            $ref: '#/definitions/chatservice.Error'
         "404":
           description: Room not found
           schema:
             $ref: '#/definitions/chatservice.Error'
         "500":
-          description: Internal server error during processing
+          description: Internal server error
           schema:
             $ref: '#/definitions/chatservice.Error'
-      summary: GetRooms
-  /api/lock-room/:
+      summary: Get Room Details
+      tags:
+      - rooms
+  /api/v1/rooms/{roomId}/lock:
     post:
-      description: Will lock a room for the user. If the room is already locked by
-        the user, it will unlock the room.
+      description: Controls the lock status of a chat room. Locks room for exclusive
+        use by a user or unlocks if already locked by same user.
+      parameters:
+      - description: Room ID (required)
+        in: path
+        name: roomId
+        required: true
+        type: string
+      - description: User information for locking the room
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/chatservice.LockRoomBody'
+      produces:
+      - application/json
       responses:
         "200":
-          description: Successfully processed chat
+          description: Room lock status updated successfully
           schema:
-            $ref: '#/definitions/chatservice.Response'
+            additionalProperties:
+              type: string
+            type: object
         "400":
-          description: Invalid request body
+          description: Bad request or missing required fields
           schema:
-            $ref: '#/definitions/chatservice.Response'
+            $ref: '#/definitions/chatservice.Error'
+        "403":
+          description: User not authorized to lock room
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+        "404":
+          description: Room not found
+          schema:
+            $ref: '#/definitions/chatservice.Error'
         "500":
-          description: Internal server error during processing
+          description: Internal server error
           schema:
-            $ref: '#/definitions/chatservice.Response'
-      summary: LockRoom
-  /api/register-user/:
-    post:
-      description: Will register a user in a room. If the user is already registered,
-        it will return the room without error.
-      responses:
-        "200":
-          description: Successfully processed chat
-          schema:
-            $ref: '#/definitions/chatservice.RegisterUserResponse'
-        "400":
-          description: Invalid request body
-          schema:
-            $ref: '#/definitions/chatservice.Response'
-        "500":
-          description: Internal server error during processing
-          schema:
-            $ref: '#/definitions/chatservice.Response'
-      summary: RegisterUser
-  /api/ws/:
+            $ref: '#/definitions/chatservice.Error'
+      summary: Lock or Unlock Room
+      tags:
+      - rooms
+  /api/v1/rooms/{roomId}/messages:
     get:
-      description: WebSocket
+      description: Fetches paginated messages for a specific chat room
+      parameters:
+      - description: Room ID (required)
+        in: path
+        name: roomId
+        required: true
+        type: string
+      - description: 'Page number (default: 1)'
+        in: query
+        minimum: 1
+        name: page
+        type: integer
+      - description: 'Items per page (default: 50)'
+        in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      produces:
+      - application/json
       responses:
         "200":
-          description: Successfully processed chat
+          description: Messages retrieved successfully
           schema:
-            $ref: '#/definitions/chatservice.Response'
+            items:
+              $ref: '#/definitions/chatservice.ChatMessage'
+            type: array
         "400":
-          description: Invalid request body
+          description: Bad request or missing room ID
           schema:
-            $ref: '#/definitions/chatservice.Response'
+            $ref: '#/definitions/chatservice.Error'
+        "404":
+          description: Room not found
+          schema:
+            $ref: '#/definitions/chatservice.Error'
         "500":
-          description: Internal server error during processing
+          description: Internal server error
           schema:
-            $ref: '#/definitions/chatservice.Response'
-      summary: WebSocket
+            $ref: '#/definitions/chatservice.Error'
+      summary: Retrieve Room Messages
+      tags:
+      - messages
+      - rooms
+  /api/v1/rooms/{roomId}/register-user:
+    post:
+      description: Adds a user to a chat room. Creates new user if needed. Returns
+        existing room if user already registered.
+      parameters:
+      - description: Room ID (required)
+        in: path
+        name: roomId
+        required: true
+        type: string
+      - description: User information for registration
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/chatservice.RegisterUserBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: User successfully registered to room
+          schema:
+            $ref: '#/definitions/repositories.Room'
+        "400":
+          description: Bad request or invalid input
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+        "404":
+          description: Room not found
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/chatservice.Error'
+      summary: Register User to Room
+      tags:
+      - rooms
+      - users
+  /api/v1/ws:
+    get:
+      description: Establishes a WebSocket connection for real-time messaging in a
+        chat room
+      parameters:
+      - description: Authentication token (required)
+        in: query
+        name: token
+        required: true
+        type: string
+      - description: User ID (required)
+        in: query
+        name: user_id
+        required: true
+        type: string
+      - description: Room ID (required)
+        in: query
+        name: room_id
+        required: true
+        type: string
+      - description: User's display name (required)
+        in: query
+        name: nickname
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "101":
+          description: WebSocket connection successfully upgraded
+          schema:
+            $ref: '#/definitions/chatservice.ChatMessage'
+        "400":
+          description: Missing required parameters or invalid request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized - Missing or invalid token
+          schema:
+            type: string
+        "403":
+          description: Forbidden - User not authorized to join room
+          schema:
+            type: string
+        "404":
+          description: Room not found
+          schema:
+            type: string
+        "500":
+          description: Internal server error
+          schema:
+            type: string
+      summary: Real-time Chat WebSocket Connection
+      tags:
+      - websocket
+      - rooms
 swagger: "2.0"


### PR DESCRIPTION
- Add comprehensive Swagger documentation to auth service endpoints (register, login, delete)
- Add detailed Swagger documentation to chat service endpoints (websocket, rooms, messages)
- Standardize API path structure in documentation to follow RESTful conventions
- Improve parameter descriptions and response type documentation
- Include appropriate status codes and error response details
- Add security requirements for authenticated endpoints
- Remove unnecessary types and organize documentation with proper tags